### PR TITLE
Ensure install after zsh and fish

### DIFF
--- a/src/shell-history/devcontainer-feature.json
+++ b/src/shell-history/devcontainer-feature.json
@@ -10,5 +10,9 @@
             "target": "/dc/shellhistory",
             "type": "volume"
         }
-    ]    
+    ],
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/meaningful-ooo/devcontainer-features/fish"
+    ]
 }


### PR DESCRIPTION
I thought these needed to be run before this feature because `ghcr.io/devcontainers/features/common-utils` installs zsh and `ghcr.io/meaningful-ooo/devcontainer-features/fish` installs fish.