### PR TITLE
fix(shell-history): no longer check for env vars during installation

### DIFF
--- a/src/shell-history/install.sh
+++ b/src/shell-history/install.sh
@@ -5,14 +5,6 @@ LIFECYCLE_SCRIPTS_DIR="/usr/local/share/stuartleeks-devcontainer-features/shell-
 set -e
 
 echo "Activating feature 'shell-history'"
-echo "User: ${_REMOTE_USER}     User home: ${_REMOTE_USER_HOME}"
-
-if [  -z "$_REMOTE_USER" ] || [ -z "$_REMOTE_USER_HOME" ]; then
-  echo "***********************************************************************************"
-  echo "*** Require _REMOTE_USER and _REMOTE_USER_HOME to be set (by dev container CLI) ***"
-  echo "***********************************************************************************"
-  exit 1
-fi
 
 # Set Lifecycle script
 if [ -f oncreate.sh ]; then


### PR DESCRIPTION
Fixes: https://github.com/stuartleeks/dev-container-features/issues/11#issuecomment-3140543411

#16 removed the use of the `_REMOTE_` env variables during installation, but the script still verifies that they're present.
